### PR TITLE
Add dbify processing qc

### DIFF
--- a/bripipetools/__init__.py
+++ b/bripipetools/__init__.py
@@ -1,6 +1,6 @@
 __author__ = 'James A. Eddy'
 __email__ = 'james.a.eddy@gmail.com'
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 from . import util
 

--- a/bripipetools/dbify/processing.py
+++ b/bripipetools/dbify/processing.py
@@ -54,7 +54,7 @@ class ProcessingImporter(object):
             workflowbatch_file=self.path,
             genomics_root=path_items['genomics_root'],
             db=self.db
-            ).get_processed_libraries()
+            ).get_processed_libraries(qc=True)
 
     def _insert_workflowbatch(self):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.2.1
 commit = True
 tag = True
 
@@ -15,3 +15,4 @@ addopts = --cov bripipetools --ignore=tests/test_globusgalaxy.py
 
 [tool:pytest]
 addopts = --cov bripipetools --ignore=tests/test_globusgalaxy.py
+

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
 
 config = {
     'name': 'bripipetools',
-    'version': '0.2.0',
+    'version': '0.2.1',
     'description': 'Software for managing BRI bioinformatics pipelines',
     'author': 'James A. Eddy',
     'author_email': 'james.a.eddy@gmail.com',


### PR DESCRIPTION
Small patch: add `qc=True` to `_collect_processedlibraries()` method in `processing` submodule in `dbify` module (so that QC fields actually get added before import).