### PR TITLE
Conda for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,32 @@
-
 # Config file for automatic testing at travis-ci.org
-
+# follows example from:
+# http://conda.pydata.org/docs/travis.html
 language: python
-
 python:
     - "2.7"
 
-# command to install dependencies
+# commands to set up conda
+before_install:
+    - sudo apt-get update
+    # We do this conditionally because it saves us some downloading if the
+    # version is the same.
+    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+        wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+      else
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+      fi
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - hash -r
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update -q conda
+    # Useful for debugging any issues with conda
+    - conda info -a
+
+# commands set up environment, install dependencies
 install:
-    - pip install cython
+    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION bs4 pymongo pandas
+    - source activate test-environment
     - pip install python-coveralls
     - pip install .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ before_install:
 
 # commands set up environment, install dependencies
 install:
-    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION beautifulsoup4 pymongo pandas
+    - deps='pip beautifulsoup4 pymongo pandas pytest'
+    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION $deps
     - source activate test-environment
     - pip install python-coveralls
     - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 
 # commands set up environment, install dependencies
 install:
-    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION bs4 pymongo pandas
+    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION beautifulsoup4 pymongo pandas
     - source activate test-environment
     - pip install python-coveralls
     - pip install .

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ config = {
     'license': 'MIT',
     'packages': ['bripipetools'],
     'install_requires': [
-        'bs4',
+        'beautifulsoup4',
         'pymongo',
         'pandas'
     ],


### PR DESCRIPTION
Update TravisCI config to use `conda` for setting up test environment and installing dependencies (cuts time from 8+ minutes with `pip` down to ~2 minutes)