### PR TITLE
Add cleanup module

### DIFF
--- a/bin/bripipe-postprocess
+++ b/bin/bripipe-postprocess
@@ -18,9 +18,12 @@ def parse_input_args(parser=None):
                               "Project_P69Processed"))
     parser.add_argument('-t', '--output_type',
                         default=None,
-                        choices=['c', 'm', 'b'],
+                        choices=['c', 'm', 'q', 'a'],
                         help=("Select type of result file to combine: "
-                              "c [counts], m [metrics], b [both]"))
+                              "c [counts], m [metrics], q [qc], a [all"))
+    parser.add_argument('-c', '--clean_outputs',
+                        action='store_true',
+                        help=("Attempt to clean/organize output files"))
     parser.add_argument('-d', '--debug',
                         action='store_true',
                         help=("Set logging level to debug"))
@@ -40,18 +43,30 @@ def main(argv):
         logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(__name__)
 
+    if args.clean_outputs:
+        logging.info("cleaning output files for {}"
+                     .format(args.processed_project_path))
+        path = args.processed_project_path
+        postprocess.OutputCleaner(path).clean_outputs()
+
     logger.info("combining output files for {} with option {}"
                 .format(args.processed_project_path, args.output_type))
 
-    if args.output_type == 'c' or args.output_type == 'b':
+    if args.output_type in ['c', 'a']:
         logger.info("generating combined counts file")
         path = os.path.join(args.processed_project_path, 'counts')
         postprocess.OutputStitcher(path).write_table()
 
-    if args.output_type == 'm' or args.output_type == 'b':
+    if args.output_type in ['m', 'a']:
         logger.info("generating combined metrics file")
         path = os.path.join(args.processed_project_path, 'metrics')
         postprocess.OutputStitcher(path).write_table()
+
+    if args.output_type in ['q', 'a']:
+        logger.info("generating combined QC file(s)")
+        path = os.path.join(args.processed_project_path, 'QC')
+        postprocess.OutputStitcher(path).write_table()
+        postprocess.OutputStitcher(path).write_overrepresented_seq_table()
 
 if __name__ == "__main__":
    main(sys.argv[1:])

--- a/bripipetools/postprocess/__init__.py
+++ b/bripipetools/postprocess/__init__.py
@@ -2,3 +2,4 @@
 Classes for performing post-processing operations on batch output files.
 """
 from .stitching import OutputStitcher
+from .cleanup import OutputCleaner

--- a/bripipetools/postprocess/cleanup.py
+++ b/bripipetools/postprocess/cleanup.py
@@ -53,6 +53,12 @@ class OutputCleaner(object):
         with zipfile.ZipFile(path) as zf:
             zf.extractall(os.path.dirname(path))
 
+        # plist = []
+        # with zipfile.ZipFile(path) as zf:
+        #     for f in zf.namelist():
+        #         plist.append(zf.extract(f))
+        # return plist
+
     def _unnest_output(self, path):
         """
         Unnest files in a subfolder by concatenating filenames and

--- a/bripipetools/postprocess/cleanup.py
+++ b/bripipetools/postprocess/cleanup.py
@@ -1,0 +1,83 @@
+"""
+Clean up & organize outputs from processing workflow batch.
+"""
+import logging
+logger = logging.getLogger(__name__)
+import os
+import re
+import zipfile
+import shutil
+
+from .. import util
+from .. import parsing
+from .. import genlims
+from .. import model as docs
+
+class OutputCleaner(object):
+    """
+    Moves, renames, and deletes individual output files from a workflow
+    processing batch for a selected project.
+    """
+    def __init__(self, path):
+        logger.info("creating instance of OutputCleaner")
+        self.path = path
+        self.output_types = self._get_output_types()
+
+    def _get_output_types(self):
+        """
+        Identify the types of outputs included for the project.
+        """
+        OUT_TYPES = ['qc', 'metrics', 'counts', 'alignments', 'logs']
+
+        logging.debug("subfolders in project folder: {}"
+                      .format(os.listdir(self.path)))
+        return [f for f in os.listdir(self.path)
+                if f.lower() in OUT_TYPES]
+
+    def _get_output_paths(self, output_type):
+        """
+        Return full path for individual output files.
+        """
+        logging.debug("locating output files of type {}".format(output_type))
+        output_root = os.path.join(self.path, output_type)
+        return [os.path.join(self.path, root, f)
+                for root, dirs, files in os.walk(output_root)
+                for f in files]
+
+    def _unzip_output(self, path):
+        """
+        Unzip the contents of a compressed output file.
+        """
+        logging.debug("extracting contents of {} to {}"
+                      .format(path, os.path.dirname(path)))
+        with zipfile.ZipFile(path) as zf:
+            zf.extractall(os.path.dirname(path))
+
+    def _unnest_output(self, path):
+        """
+        Unnest files in a subfolder by concatenating filenames and
+        moving up one level.
+        """
+        logging.debug("unnesting output {} from subfolder {}"
+                      .format(path, os.path.dirname(path)))
+        prefix = os.path.dirname(path)
+        shutil.move(path, '{}_{}'.format(prefix, os.path.basename(path)))
+
+    # def clean_outputs(self):
+    #     """
+    #     Walk through output types to unzip and unnest files.
+    #     """
+    #     for output_type in self.output_types:
+    #         if output_type == 'QC':
+    #             outputs = self._get_output_paths(output_type)
+    #             for o in outputs:
+    # QC/
+    # |-lib10516_C8HAWANXX/
+    #   |-----------------qcR1.zip/
+    #                     |-------(fastqc_data.txt)
+    #                     |-------(fastqc_report.html)
+
+
+
+
+    # def _uzip_output(self, output):

--- a/bripipetools/postprocess/cleanup.py
+++ b/bripipetools/postprocess/cleanup.py
@@ -42,7 +42,8 @@ class OutputCleaner(object):
         output_root = os.path.join(self.path, output_type)
         return [os.path.join(self.path, root, f)
                 for root, dirs, files in os.walk(output_root)
-                for f in files]
+                for f in files
+                if not re.search('(DS_Store|_old)', f)]
 
     def _unzip_output(self, path):
         """
@@ -70,6 +71,10 @@ class OutputCleaner(object):
                           .format(path))
             for p in self._unzip_output(path):
                 shutil.move(p, '{}_{}'.format(prefix, os.path.basename(p)))
+            try:
+                shutil.rmtree(os.path.splitext(path)[0])
+            except OSError:
+                pass
         else:
             shutil.move(path, '{}_{}'.format(prefix, os.path.basename(path)))
 
@@ -95,6 +100,6 @@ class OutputCleaner(object):
                     outregex = re.compile(output_type + '$')
                     if not outregex.search(os.path.dirname(o)):
                         self._unnest_output(o)
-            for o in os.listdir(os.path.join(self.path, output_type)):
-                self._recode_output(os.path.join(self.path, output_type, o),
-                                    output_type)
+                for o in os.listdir(os.path.join(self.path, output_type)):
+                    self._recode_output(os.path.join(self.path, output_type, o),
+                                        output_type)


### PR DESCRIPTION
New `cleanup` submodule in `postprocess` module for unzipping, unnesting, and relabeling output files (currently only works for QC outputs).