### PR TITLE
add genlims ops method for querying for a field among sample ancestors

### DIFF
--- a/bripipetools/genlims/__init__.py
+++ b/bripipetools/genlims/__init__.py
@@ -5,5 +5,5 @@ from .connection import db
 from .operations import (find_objects, insert_objects,
                          get_samples, get_runs, get_workflowbatches,
                          put_samples, put_runs, put_workflowbatches,
-                         create_workflowbatch_id)
+                         create_workflowbatch_id, search_ancestors)
 from .mapping import (map_keys, get_model_class, map_to_object)

--- a/bripipetools/genlims/operations.py
+++ b/bripipetools/genlims/operations.py
@@ -119,3 +119,21 @@ def create_workflowbatch_id(db, prefix, date):
                 break
 
     return '{}_{}_{}'.format(prefix, isodate, num)
+
+def search_ancestors(db, sample_id, field):
+    """
+    Given an object in the 'samples' collection, specified by the input
+    ID, iteratively walk through ancestors based on 'parentId' until
+    a value is found for the requested field.
+    """
+    sample = db.samples.find_one({'_id': sample_id})
+    if field in sample:
+        return sample[field]
+    else:
+        try:
+            return search_ancestors(db, sample['parentId'], field)
+        except KeyError:
+            logger.debug("input sample '{}' has no mapped parent sample"
+                         .format(sample_id),
+                         exc_info=True)
+            return

--- a/tests/test_genlims.py
+++ b/tests/test_genlims.py
@@ -281,6 +281,95 @@ class TestGenLIMSOperations:
         # THEN constructed workflow batch ID should end in number 2
         assert(wb_id == 'mockprefix_2000-01-01_2')
 
+    def test_search_ancestors_field_in_sample(self, mock_db):
+        # GIVEN an existing sample with a field that matches the input
+        # argument
+        logger.info("test `search_ancestors()`, sample has field")
+
+        mock_db.samples.insert(
+            {'_id': 'mocksample',
+             'parentId': 'mockparent',
+             'mockfield': 'mockvalue'})
+
+        # WHEN searching for the field among all sample ancestors
+        value = genlims.search_ancestors(mock_db, 'mocksample', 'mockfield')
+
+        # THEN should return the value of the field from the first sample
+        # checked
+        assert(value == 'mockvalue')
+
+    def test_search_ancestors_field_in_parent(self, mock_db):
+        # GIVEN an existing sample with a parent sample that includes the
+        # input field
+        logger.info("test `search_ancestors()`, parent has field")
+
+        mock_db.samples.insert(
+            {'_id': 'mocksample',
+             'parentId': 'mockparent'})
+        mock_db.samples.insert(
+            {'_id': 'mockparent',
+             'mockfield': 'mockvalue'})
+
+        # WHEN searching for the field among all sample ancestors
+        value = genlims.search_ancestors(mock_db, 'mocksample', 'mockfield')
+
+        # THEN should return the value of the field from the parent sample
+        assert(value == 'mockvalue')
+
+    def test_search_ancestors_field_in_grandparent(self, mock_db):
+        # GIVEN an existing sample with a grandparent sample (parent of a
+        # parent) that includes the input field
+        logger.info("test `search_ancestors()`, grandparent has field")
+
+        mock_db.samples.insert(
+            {'_id': 'mocksample',
+             'parentId': 'mockparent'})
+        mock_db.samples.insert(
+            {'_id': 'mockparent',
+             'parentId': 'mockgrandparent'})
+        mock_db.samples.insert(
+            {'_id': 'mockgrandparent',
+             'mockfield': 'mockvalue'})
+
+        # WHEN searching for the field among all sample ancestors
+        value = genlims.search_ancestors(mock_db, 'mocksample', 'mockfield')
+
+        # THEN should return the value of the field from the parent sample
+        assert(value == 'mockvalue')
+
+    def test_search_ancestors_no_parent(self, mock_db):
+        # GIVEN an existing sample with that has no 'parentId' field
+        logger.info("test `search_ancestors()`, no parent indicated")
+
+        mock_db.samples.insert(
+            {'_id': 'mocksample'})
+        mock_db.samples.insert(
+            {'_id': 'mockparent',
+             'mockfield': 'mockvalue'})
+
+        # WHEN searching for the field among all sample ancestors
+        value = genlims.search_ancestors(mock_db, 'mocksample', 'mockfield')
+
+        # THEN should return None
+        assert(value is None)
+
+    def test_search_ancestors_no_field(self, mock_db):
+        # GIVEN an existing sample with no ancestors that include the
+        # input field
+        logger.info("test `search_ancestors()`, no parent indicated")
+
+        mock_db.samples.insert(
+            {'_id': 'mocksample',
+             'parentId': 'mockparent'})
+        mock_db.samples.insert(
+            {'_id': 'mockparent'})
+
+        # WHEN searching for the field among all sample ancestors
+        value = genlims.search_ancestors(mock_db, 'mocksample', 'mockfield')
+
+        # THEN should return None
+        assert(value is None)
+
 
 class TestMapping:
     # GIVEN any state


### PR DESCRIPTION
Method/function `genlims.search_ancestors()` will start on the specified sample (given sample ID) and continue looking back through parent samples the specified field is found, then return that value (or `None`, if the field isn't found).