### PR TITLE
break out classes for different types of annotators into separate submodules

### DIFF
--- a/bripipetools/annotation/__init__.py
+++ b/bripipetools/annotation/__init__.py
@@ -9,5 +9,7 @@ are retrieved directly from the database; for new objects or objects
 with missing fields, information is compiled, parsed, and formatted
 (as needed) from files on the server.
 """
-from .illuminaseq import FlowcellRunAnnotator, SequencedLibraryAnnotator
-from .globusgalaxy import WorkflowBatchAnnotator, ProcessedLibraryAnnotator
+from .sequencedlibs import SequencedLibraryAnnotator
+from .flowcellruns import FlowcellRunAnnotator
+from .processedlibs import ProcessedLibraryAnnotator
+from .workflowbatches import WorkflowBatchAnnotator

--- a/bripipetools/annotation/flowcellruns.py
+++ b/bripipetools/annotation/flowcellruns.py
@@ -9,6 +9,7 @@ import re
 from .. import parsing
 from .. import genlims
 from .. import model as docs
+from . import SequencedLibraryAnnotator
 
 logger = logging.getLogger(__name__)
 
@@ -129,67 +130,67 @@ class FlowcellRunAnnotator(object):
         return sequencedlibraries
 
 
-class SequencedLibraryAnnotator(object):
-    """
-    Identifies, stores, and updates information about a sequenced library.
-    """
-    def __init__(self, path, library, project, run_id, db):
-        logger.info("creating an instance of SequencedLibraryAnnotator "
-                    "for library {}".format(library))
-        self.path = path
-        self.db = db
-        self.library_id = parsing.get_library_id(library)
-        self.project_label = parsing.get_project_label(project)
-        self.run_id = run_id
-        self.run_items = parsing.parse_flowcell_run_id(run_id)
-        self.seqlib_id = '{}_{}'.format(self.library_id,
-                                        self.run_items['flowcell_id'])
-        self.sequencedlibrary = self._init_sequencedlibrary()
-
-    def _init_sequencedlibrary(self):
-        """
-        Try to retrieve data for the sequenced library from GenLIMS;
-        if unsuccessful, create new ``SequencedLibrary`` object.
-        """
-        logger.info("initializing SequencedLibrary instance")
-        try:
-            logger.debug("getting SequencedLibrary from GenLIMS")
-            return genlims.map_to_object(
-                genlims.get_samples(self.db, {'_id': self.seqlib_id})[0])
-        except IndexError:
-            logger.debug("creating new SequencedLibrary object")
-            return docs.SequencedLibrary(_id=self.seqlib_id)
-
-    def _get_raw_data(self):
-        """
-        Locate and store details about raw data for sequenced library.
-        """
-        logger.debug("collecting raw data details for library {}".format(
-            self.library_id))
-        return [parsing.parse_fastq_filename(f)
-                for f in os.listdir(self.path)
-                if not re.search('empty', f)]
-
-    def _update_sequencedlibrary(self):
-        """
-        Add any missing fields to SequencedLibrary object.
-        """
-        logger.debug("updating SequencedLibrary object attributes")
-
-        project_items = parsing.parse_project_label(self.project_label)
-        update_fields = {'project_id': project_items['project_id'],
-                         'subproject_id': project_items['subproject_id'],
-                         'run_id': self.run_id,
-                         'parent_id': self.library_id,
-                         'raw_data': self._get_raw_data()}
-        self.sequencedlibrary.is_mapped = False
-        self.sequencedlibrary.update_attrs(update_fields, force=True)
-
-    def get_sequenced_library(self):
-        """
-        Return sequenced library object with updated fields.
-        """
-        self._update_sequencedlibrary()
-        logger.debug("returning sequenced library object: {}".format(
-            self.sequencedlibrary.__dict__))
-        return self.sequencedlibrary
+# class SequencedLibraryAnnotator(object):
+#     """
+#     Identifies, stores, and updates information about a sequenced library.
+#     """
+#     def __init__(self, path, library, project, run_id, db):
+#         logger.info("creating an instance of SequencedLibraryAnnotator "
+#                     "for library {}".format(library))
+#         self.path = path
+#         self.db = db
+#         self.library_id = parsing.get_library_id(library)
+#         self.project_label = parsing.get_project_label(project)
+#         self.run_id = run_id
+#         self.run_items = parsing.parse_flowcell_run_id(run_id)
+#         self.seqlib_id = '{}_{}'.format(self.library_id,
+#                                         self.run_items['flowcell_id'])
+#         self.sequencedlibrary = self._init_sequencedlibrary()
+#
+#     def _init_sequencedlibrary(self):
+#         """
+#         Try to retrieve data for the sequenced library from GenLIMS;
+#         if unsuccessful, create new ``SequencedLibrary`` object.
+#         """
+#         logger.info("initializing SequencedLibrary instance")
+#         try:
+#             logger.debug("getting SequencedLibrary from GenLIMS")
+#             return genlims.map_to_object(
+#                 genlims.get_samples(self.db, {'_id': self.seqlib_id})[0])
+#         except IndexError:
+#             logger.debug("creating new SequencedLibrary object")
+#             return docs.SequencedLibrary(_id=self.seqlib_id)
+#
+#     def _get_raw_data(self):
+#         """
+#         Locate and store details about raw data for sequenced library.
+#         """
+#         logger.debug("collecting raw data details for library {}".format(
+#             self.library_id))
+#         return [parsing.parse_fastq_filename(f)
+#                 for f in os.listdir(self.path)
+#                 if not re.search('empty', f)]
+#
+#     def _update_sequencedlibrary(self):
+#         """
+#         Add any missing fields to SequencedLibrary object.
+#         """
+#         logger.debug("updating SequencedLibrary object attributes")
+#
+#         project_items = parsing.parse_project_label(self.project_label)
+#         update_fields = {'project_id': project_items['project_id'],
+#                          'subproject_id': project_items['subproject_id'],
+#                          'run_id': self.run_id,
+#                          'parent_id': self.library_id,
+#                          'raw_data': self._get_raw_data()}
+#         self.sequencedlibrary.is_mapped = False
+#         self.sequencedlibrary.update_attrs(update_fields, force=True)
+#
+#     def get_sequenced_library(self):
+#         """
+#         Return sequenced library object with updated fields.
+#         """
+#         self._update_sequencedlibrary()
+#         logger.debug("returning sequenced library object: {}".format(
+#             self.sequencedlibrary.__dict__))
+#         return self.sequencedlibrary

--- a/bripipetools/annotation/processedlibs.py
+++ b/bripipetools/annotation/processedlibs.py
@@ -1,0 +1,126 @@
+"""
+
+"""
+import logging
+import re
+
+from .. import util
+from .. import genlims
+from .. import model as docs
+
+logger = logging.getLogger(__name__)
+
+
+class ProcessedLibraryAnnotator(object):
+    """
+    Identifies, stores, and updates information about a processed library.
+    """
+    def __init__(self, workflowbatch_id, params, db):
+        logger.info("creating an instance of ProcessedLibraryAnnotator")
+        self.workflowbatch_id = workflowbatch_id
+        logger.debug("workflowbatch_id set to {}".format(workflowbatch_id))
+        self.db = db
+        self.params = params
+        self.seqlib_id = self._get_seqlib_id()
+        self.proclib_id = '{}_processed'.format(self.seqlib_id)
+        self.processedlibrary = self._init_processedlibrary()
+
+    def _get_seqlib_id(self):
+        """
+        Return the ID of the parent sequenced library.
+        """
+        return [p['value'] for p in self.params
+                if p['name'] == 'SampleName'][0]
+
+    def _init_processedlibrary(self):
+        """
+        Try to retrieve data for the processed library from GenLIMS;
+        if unsuccessful, create new ``ProcessedLibrary`` object.
+        """
+        logger.info("initializing ProcessedLibrary instance")
+
+        try:
+            logger.debug("getting ProcessedLibrary from GenLIMS")
+            return genlims.map_to_object(
+                genlims.get_samples(self.db, {'_id': self.proclib_id})[0])
+        except IndexError:
+            logger.debug("creating new ProcessedLibrary object")
+            return docs.ProcessedLibrary(_id=self.proclib_id)
+
+    def _get_outputs(self):
+        """
+        Return the list of outputs from the processing workflow batch.
+        """
+        return {p['tag']: p['value'] for p in self.params
+                if p['type'] == 'output' and p['name'] == 'to_path'}
+
+    def _parse_output_name(self, output_name):
+        """
+        Parse output name indicated by parameter tag in workflow batch
+        submit file and return individual components indicating name,
+        source, and type.
+        """
+        name = re.sub('_out', '', output_name)
+        name_parts = name.split('_')
+        file_format = name_parts.pop(-1)
+        output_type = name_parts.pop(-1)
+        source = '_'.join(name_parts)
+
+        return {'name': name, 'type': output_type, 'source': source}
+
+    def _group_outputs(self):
+        """
+        Organize outputs according to type and source.
+        """
+        outputs = self._get_outputs()
+        grouped_outputs = {}
+        for k, v in outputs.items():
+            if 'fastq_' not in k:
+                output_items = self._parse_output_name(k)
+                grouped_outputs.setdefault(
+                    output_items['type'], []
+                    ).append(
+                        {'source': output_items['source'],
+                         'file': util.swap_root(v, 'genomics', '/'),
+                         'name': output_items['name']})
+        return grouped_outputs
+
+    def _append_processed_data(self):
+        """
+        Add details and outputs for current workflow batch to processed
+        data array field for processed library.
+        """
+        processed_data = self.processedlibrary.processed_data
+        if (not len(processed_data)
+                or not any(d['workflowbatch_id'] == self.workflowbatch_id
+                           for d in processed_data)):
+            logger.debug("inserting outputs from new workflow batch {} "
+                         "for processed library {}"
+                         .format(self.workflowbatch_id, self.proclib_id))
+            self.processedlibrary.processed_data.append(
+                {'workflowbatch_id': self.workflowbatch_id,
+                 'outputs': self._group_outputs()})
+        else:
+            logger.debug("updating outputs from workflow batch {} "
+                         "for processed library {}"
+                         .format(self.workflowbatch_id, self.proclib_id))
+            batch_data = [d for d in processed_data
+                          if d['workflowbatch_id'] == self.workflowbatch_id][0]
+            batch_data['outputs'] = self._group_outputs()
+
+    def _update_processedlibrary(self):
+        """
+        Add or update any missing fields in ProcessedLibrary object.
+        """
+        self._append_processed_data()
+
+        update_fields = {'parent_id': self.seqlib_id}
+        self.processedlibrary.is_mapped = False
+        self.processedlibrary.update_attrs(update_fields, force=True)
+
+    def get_processed_library(self):
+        """
+        Return updated ProcessedLibrary object.
+        """
+        self._update_processedlibrary()
+        return self.processedlibrary

--- a/bripipetools/annotation/sequencedlibs.py
+++ b/bripipetools/annotation/sequencedlibs.py
@@ -1,0 +1,79 @@
+"""
+Classify / provide details for sequenced libraries (outputs of a
+flowcell sequencing run) and the associated raw data.
+"""
+import logging
+import os
+import re
+
+from .. import parsing
+from .. import genlims
+from .. import model as docs
+
+logger = logging.getLogger(__name__)
+
+
+class SequencedLibraryAnnotator(object):
+    """
+    Identifies, stores, and updates information about a sequenced library.
+    """
+    def __init__(self, path, library, project, run_id, db):
+        logger.info("creating an instance of SequencedLibraryAnnotator "
+                    "for library {}".format(library))
+        self.path = path
+        self.db = db
+        self.library_id = parsing.get_library_id(library)
+        self.project_label = parsing.get_project_label(project)
+        self.run_id = run_id
+        self.run_items = parsing.parse_flowcell_run_id(run_id)
+        self.seqlib_id = '{}_{}'.format(self.library_id,
+                                        self.run_items['flowcell_id'])
+        self.sequencedlibrary = self._init_sequencedlibrary()
+
+    def _init_sequencedlibrary(self):
+        """
+        Try to retrieve data for the sequenced library from GenLIMS;
+        if unsuccessful, create new ``SequencedLibrary`` object.
+        """
+        logger.info("initializing SequencedLibrary instance")
+        try:
+            logger.debug("getting SequencedLibrary from GenLIMS")
+            return genlims.map_to_object(
+                genlims.get_samples(self.db, {'_id': self.seqlib_id})[0])
+        except IndexError:
+            logger.debug("creating new SequencedLibrary object")
+            return docs.SequencedLibrary(_id=self.seqlib_id)
+
+    def _get_raw_data(self):
+        """
+        Locate and store details about raw data for sequenced library.
+        """
+        logger.debug("collecting raw data details for library {}".format(
+            self.library_id))
+        return [parsing.parse_fastq_filename(f)
+                for f in os.listdir(self.path)
+                if not re.search('empty', f)]
+
+    def _update_sequencedlibrary(self):
+        """
+        Add any missing fields to SequencedLibrary object.
+        """
+        logger.debug("updating SequencedLibrary object attributes")
+
+        project_items = parsing.parse_project_label(self.project_label)
+        update_fields = {'project_id': project_items['project_id'],
+                         'subproject_id': project_items['subproject_id'],
+                         'run_id': self.run_id,
+                         'parent_id': self.library_id,
+                         'raw_data': self._get_raw_data()}
+        self.sequencedlibrary.is_mapped = False
+        self.sequencedlibrary.update_attrs(update_fields, force=True)
+
+    def get_sequenced_library(self):
+        """
+        Return sequenced library object with updated fields.
+        """
+        self._update_sequencedlibrary()
+        logger.debug("returning sequenced library object: {}".format(
+            self.sequencedlibrary.__dict__))
+        return self.sequencedlibrary

--- a/bripipetools/annotation/workflowbatches.py
+++ b/bripipetools/annotation/workflowbatches.py
@@ -5,7 +5,6 @@ Core.
 """
 import logging
 import os
-import re
 import datetime
 
 from .. import util
@@ -13,6 +12,7 @@ from .. import io
 from .. import genlims
 from .. import qc
 from .. import model as docs
+from . import ProcessedLibraryAnnotator
 
 logger = logging.getLogger(__name__)
 
@@ -183,116 +183,4 @@ class WorkflowBatchAnnotator(object):
             ]
 
 
-class ProcessedLibraryAnnotator(object):
-    """
-    Identifies, stores, and updates information about a processed library.
-    """
-    def __init__(self, workflowbatch_id, params, db):
-        logger.info("creating an instance of ProcessedLibraryAnnotator")
-        self.workflowbatch_id = workflowbatch_id
-        logger.debug("workflowbatch_id set to {}".format(workflowbatch_id))
-        self.db = db
-        self.params = params
-        self.seqlib_id = self._get_seqlib_id()
-        self.proclib_id = '{}_processed'.format(self.seqlib_id)
-        self.processedlibrary = self._init_processedlibrary()
 
-    def _get_seqlib_id(self):
-        """
-        Return the ID of the parent sequenced library.
-        """
-        return [p['value'] for p in self.params
-                if p['name'] == 'SampleName'][0]
-
-    def _init_processedlibrary(self):
-        """
-        Try to retrieve data for the processed library from GenLIMS;
-        if unsuccessful, create new ``ProcessedLibrary`` object.
-        """
-        logger.info("initializing ProcessedLibrary instance")
-
-        try:
-            logger.debug("getting ProcessedLibrary from GenLIMS")
-            return genlims.map_to_object(
-                genlims.get_samples(self.db, {'_id': self.proclib_id})[0])
-        except IndexError:
-            logger.debug("creating new ProcessedLibrary object")
-            return docs.ProcessedLibrary(_id=self.proclib_id)
-
-    def _get_outputs(self):
-        """
-        Return the list of outputs from the processing workflow batch.
-        """
-        return {p['tag']: p['value'] for p in self.params
-                if p['type'] == 'output' and p['name'] == 'to_path'}
-
-    def _parse_output_name(self, output_name):
-        """
-        Parse output name indicated by parameter tag in workflow batch
-        submit file and return individual components indicating name,
-        source, and type.
-        """
-        name = re.sub('_out', '', output_name)
-        name_parts = name.split('_')
-        file_format = name_parts.pop(-1)
-        output_type = name_parts.pop(-1)
-        source = '_'.join(name_parts)
-
-        return {'name': name, 'type': output_type, 'source': source}
-
-    def _group_outputs(self):
-        """
-        Organize outputs according to type and source.
-        """
-        outputs = self._get_outputs()
-        grouped_outputs = {}
-        for k, v in outputs.items():
-            if 'fastq_' not in k:
-                output_items = self._parse_output_name(k)
-                grouped_outputs.setdefault(
-                    output_items['type'], []
-                    ).append(
-                        {'source': output_items['source'],
-                         'file': util.swap_root(v, 'genomics', '/'),
-                         'name': output_items['name']})
-        return grouped_outputs
-
-    def _append_processed_data(self):
-        """
-        Add details and outputs for current workflow batch to processed
-        data array field for processed library.
-        """
-        processed_data = self.processedlibrary.processed_data
-        if (not len(processed_data)
-                or not any(d['workflowbatch_id'] == self.workflowbatch_id
-                           for d in processed_data)):
-            logger.debug("inserting outputs from new workflow batch {} "
-                         "for processed library {}"
-                         .format(self.workflowbatch_id, self.proclib_id))
-            self.processedlibrary.processed_data.append(
-                {'workflowbatch_id': self.workflowbatch_id,
-                 'outputs': self._group_outputs()})
-        else:
-            logger.debug("updating outputs from workflow batch {} "
-                         "for processed library {}"
-                         .format(self.workflowbatch_id, self.proclib_id))
-            batch_data = [d for d in processed_data
-                          if d['workflowbatch_id'] == self.workflowbatch_id][0]
-            batch_data['outputs'] = self._group_outputs()
-
-    def _update_processedlibrary(self):
-        """
-        Add or update any missing fields in ProcessedLibrary object.
-        """
-        self._append_processed_data()
-
-        update_fields = {'parent_id': self.seqlib_id}
-        self.processedlibrary.is_mapped = False
-        self.processedlibrary.update_attrs(update_fields, force=True)
-
-    def get_processed_library(self):
-        """
-        Return updated ProcessedLibrary object.
-        """
-        self._update_processedlibrary()
-        return self.processedlibrary


### PR DESCRIPTION
Quick fix to make organization of `annotation` submodules a bit more consistent.