### PR TITLE
use environment configs to parametrize genlims database connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ tmp
 
 # PyCharm files
 .idea
+
+# BRI-specific config files
+bri*.ini

--- a/bripipetools/genlims/connection.py
+++ b/bripipetools/genlims/connection.py
@@ -2,10 +2,37 @@
 Connect to the GenLIMS Mongo database.
 """
 import logging
+import os
+import ConfigParser
+
 import pymongo
 
 logger = logging.getLogger(__name__)
 
-logger.info("connecting to 'tg3' Mongo database")
-client = pymongo.MongoClient('localhost', 27017)
-db = client['tg3']
+
+def connect():
+    """
+    Check the current environment to determine which database
+    parameters to use, then connect to the target database on the
+    specified host.
+
+    :return: A database connection object.
+    """
+    property_file = os.environ.get('DB_PARAM_FILE')
+    if property_file is None:
+        logger.info("no environmental variable set; using 'default.ini'")
+        property_file = 'default.ini'
+    else:
+        logger.info("property file set: '{}'".format(property_file))
+
+    config = ConfigParser.ConfigParser()
+    with open(property_file) as f:
+        config.readfp(f)
+    db_host = config.get('database', 'db_host')
+    db_name = config.get('database', 'db_name')
+
+    logger.info("connecting to database '{}' on host '{}"
+                .format(db_name, db_host))
+    client = pymongo.MongoClient(db_host, 27017)
+    return client[db_name]
+db = connect()

--- a/default.ini
+++ b/default.ini
@@ -1,0 +1,3 @@
+[database]
+db_name=tg3
+db_host=localhost

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
+os.environ['DB_PARAM_FILE'] = 'default.ini'
+
 def join(loader, node):
     """
     Join YAML list items with no separator.

--- a/tests/test_genlims.py
+++ b/tests/test_genlims.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 def test_genlims_connection():
     # TODO: come up with a better way to test this
-    assert('samples' in genlims.db.collection_names())
+    assert('tg3' in genlims.db.name)
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_genlims.py
+++ b/tests/test_genlims.py
@@ -12,9 +12,10 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-# def test_genlims_connection():
-#     # TODO: come up with a better way to test this
-#     assert('samples' in genlims.db.collection_names())
+def test_genlims_connection():
+    # TODO: come up with a better way to test this
+    assert('samples' in genlims.db.collection_names())
+
 
 @pytest.fixture(scope='function')
 def mock_db():


### PR DESCRIPTION
Parse a local parameters/config (`.ini`) file to determine the host and database name to use for connection.